### PR TITLE
Fix Steam Game Detection on Linux

### DIFF
--- a/src/game_detection.rs
+++ b/src/game_detection.rs
@@ -460,7 +460,7 @@ mod detection {
 					steam_path.join("steamapps").join("libraryfolders.vdf")
 				};
 
-				if let Ok(s) = fs::read_to_string(&steam_path) {
+				if let Ok(s) = fs::read_to_string(&libraryfolders_path) {
 					let folders: HashMap<String, SteamLibraryFolder> = keyvalues_serde::from_str(&s).map_err(|x| {
 						GameDetectionError::VdfDeserialisation(libraryfolders_path.to_string_lossy().into(), x.into())
 					})?;


### PR DESCRIPTION
This PR fixes an issue where Steam game installations were no longer found on Linux. 
The problem was caused by some refactoring done during the migration of game detection code from GlacierKit to hitman-commons.
This PR fixes the issue and restores Steam game detection on Linux.